### PR TITLE
Fixed variable name in initWithUrlParams

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -273,7 +273,7 @@ $(document).ready(function() {
       var sParameterName = sURLVariables[i].split('=');
       var facet = decodeURIComponent(sParameterName[0]);
       var value = decodeURIComponent(sParameterName[1]);
-      helper.toggleRefine(facets, value, false);
+      helper.toggleRefine(facet, value, false);
     }
     // Page has to be set in the end to avoid being overwritten
     var page = decodeURIComponent(sURLVariables[1].split('=')[1])-1;


### PR DESCRIPTION
The initWithUrlParams wasn't processing the facets, I found out the name of the variable was wrong.