### PR TITLE
chore: provide an npm run dev command (with auto reload)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Algolia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -41,3 +41,13 @@ Try out the [demo](http://demos.algolia.com/instant-search-demo/)
 
 ## Data Set
 We've extracted 10,000 products from the [Best Buy Developer API](https://developer.bestbuy.com). You can find the associated documentation [here](https://developer.bestbuy.com/documentation/products-api).
+
+## Run and develop locally
+
+To hack and develop on this current repository:
+
+```sh
+git clone git@github.com:algolia/instant-search-demo.git
+npm install
+npm run dev
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "instant-search-demo",
+  "version": "1.0.0",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/algolia/instant-search-demo.git"
+  },
+  "author": "Algolia team <support@algolia.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/algolia/instant-search-demo/issues"
+  },
+  "scripts": {
+    "dev": "browser-sync start --server . --files 'css/*,img/*,js/*,index.html' --no-open"
+  },
+  "homepage": "https://github.com/algolia/instant-search-demo#readme",
+  "dependencies": {
+    "browser-sync": "2.8.1"
+  }
+}


### PR DESCRIPTION
To easily develop on the prototype:

```
npm install
npm run dev
```

Will create a server serving the demo, with auto reload.