### PR TITLE
Add support for mouse-driven searches

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -48,8 +48,9 @@ $(document).ready(function() {
 
   // Input binding
   $searchInput
-  .on('keyup', function() {
-    var query = $(this).val();
+  .on('input propertychange', function(e) {
+    var query = e.currentTarget.value;
+
     toggleIconEmptyInput(query);
     algoliaHelper.setQuery(query).search();
   })


### PR DESCRIPTION
By restricting our event bindings to only keyup, the search doesn't work if someone right-clicks and pastes a value into the input. This supports paste and cut instantly. If the user chooses 'delete' then they must leave the input box as there is no delete event and change only registers on loss of focus.