### PR TITLE
Fix: when going back to the first history step, the UI was not updated

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -13,7 +13,8 @@ $(document).ready(function() {
     hitsPerPage: 10,
     maxValuesPerFacet: 8,
     facets: ['type'],
-    disjunctiveFacets: ['categories', 'brand', 'price']
+    disjunctiveFacets: ['categories', 'brand', 'price'],
+    index: INDEX_NAME
   };
   var FACETS_SLIDER = ['price'];
   var FACETS_ORDER_OF_DISPLAY = ['categories', 'brand', 'price', 'type'];
@@ -279,9 +280,10 @@ $(document).ready(function() {
   function initFromURLParams() {
     var URLString = window.location.search.slice(1);
     var URLParams = algoliasearchHelper.url.getStateFromQueryString(URLString);
-    if (URLParams.query) $searchInput.val(URLParams.query);
-    if (URLParams.index) $sortBySelect.val(URLParams.index.replace(INDEX_NAME, ''));
-    algoliaHelper.overrideStateWithoutTriggeringChangeEvent(algoliaHelper.state.setQueryParameters(URLParams));
+    var stateFromURL = Object.assign({}, PARAMS, URLParams)
+    $searchInput.val(stateFromURL.query);
+    $sortBySelect.val(stateFromURL.index.replace(INDEX_NAME, ''));
+    algoliaHelper.overrideStateWithoutTriggeringChangeEvent(stateFromURL);
   }
 
   var URLHistoryTimer = Date.now();


### PR DESCRIPTION
## What is this PR about
Going back to the first step of the history resulted in an unexpected state.

This happened because the new state generated after the `onPopState` event was based on the previous state and the URL. When coming back to the base URL, there was no reference to any parameters but the previous content, so nothing was overridden. I updated the UI renderers accordingly. It now works based on the initial configuration, because the parameters from the URL are not self contained (which was why we were using the previous state in the first place).

Let me know if you have questions :)

## Demo

The broken state of the UI:

![first-history-step-broken](https://cloud.githubusercontent.com/assets/393765/17374529/55fad162-59ad-11e6-9fd6-9c394f90a197.gif)

Fixed:

![first-history-step-fixed](https://cloud.githubusercontent.com/assets/393765/17374540/692da598-59ad-11e6-8288-58b017a04d5f.gif)
